### PR TITLE
DM-29769: update for changes to low-level controller TCP/IP interface

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,19 @@
 Version History
 ###############
 
+v0.19.0
+-------
+
+* Update for changes to the low-level hexapod and rotator TCP/IP interfaces:
+  remove the mjd and mjd_frac fields from config and telemetry headers.
+
+Requires:
+
+* ts_salobj 6.3
+* ts_idl 2.2
+* ts_xml 7.2
+* MTRotator IDL file, e.g. built using ``make_idl_file.py MTRotator`` (for `SimpleCsc` and unit tests)
+
 v0.18.1
 -------
 

--- a/python/lsst/ts/hexrotcomm/command_telemetry_client.py
+++ b/python/lsst/ts/hexrotcomm/command_telemetry_client.py
@@ -23,8 +23,7 @@ __all__ = ["CommandTelemetryClient"]
 import abc
 import asyncio
 import math
-
-import astropy.time
+import time
 
 from lsst.ts import salobj
 from . import constants
@@ -300,12 +299,9 @@ class CommandTelemetryClient:
             Current time in header timestamp (TAI, unix seconds).
         """
         header = self.headers[frame_id]
-        curr_time = astropy.time.Time.now()
-        curr_tai = salobj.tai_from_utc(curr_time)
-        mjd_frac, mjd_days = math.modf(curr_time.utc.mjd)
-        header.mjd = int(mjd_days)
-        header.mjd_frac = mjd_frac
-        unix_frac, unix_sec = math.modf(curr_time.utc.unix)
+        curr_unix = time.time()
+        curr_tai = salobj.tai_from_utc(curr_unix)
+        unix_frac, unix_sec = math.modf(curr_unix)
         header.tv_sec = int(unix_sec)
         header.tv_nsec = int(unix_frac * 1e9)
         return header, curr_tai

--- a/python/lsst/ts/hexrotcomm/structs.py
+++ b/python/lsst/ts/hexrotcomm/structs.py
@@ -55,8 +55,6 @@ class Header(ctypes.Structure):
         ("sync_pattern", ctypes.c_ushort),
         ("frame_id", ctypes.c_ushort),
         ("counter", ctypes.c_uint),
-        ("mjd", ctypes.c_int),
-        ("mjd_frac", ctypes.c_double),
         ("tv_sec", ctypes.c_int64),
         ("tv_nsec", ctypes.c_long),
     ]


### PR DESCRIPTION
Remove mjd and mjd_frac fields from Config and Telemetry message headers
and update CommandTelemetryClient not to write them.