### PR TITLE
DM-32054: BaseCsc: remove the clearError command

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,23 @@
 Version History
 ###############
 
+v0.27.0
+-------
+
+Changes:
+
+* `BaseCsc`: remove the ``clearError`` command (which was not supported, but still present in the XML).
+  This change requires ts_xml 11.0.
+
+Requires:
+
+* ts_utils 1
+* ts_salobj 6.8
+* ts_idl 3.6
+* ts_tcpip 0.1
+* ts_xml 11.0
+* MTRotator IDL file, e.g. built using ``make_idl_file.py MTRotator`` (for `SimpleCsc` and unit tests)
+
 v0.26.0
 -------
 

--- a/python/lsst/ts/hexrotcomm/base_csc.py
+++ b/python/lsst/ts/hexrotcomm/base_csc.py
@@ -506,11 +506,6 @@ class BaseCsc(salobj.ConfigurableCsc):
         async with self.write_lock:
             await self.client.run_command(command)
 
-    async def do_clearError(self, data):
-        raise salobj.ExpectedError(
-            "Not implemented; to clear errors issue standby, start, and enable commands."
-        )
-
     def connect_callback(self, client):
         """Called when the client's command or telemetry sockets
         connect or disconnect.


### PR DESCRIPTION
(which was no longer supported but still in the XML).