### PR TITLE
DM-32902 BaseCsc: wait for telemetry when connecting

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,23 @@
 Version History
 ###############
 
+v0.28.1
+-------
+
+Changes:
+
+* Fix enabling of the low-level controller (DM-32902): wait for one telemetry sample after first connecting.
+* `BaseCsc`: eliminate the unused ``wait_summary_state`` method and add some long messages to ``enable_controller``.
+
+Requires:
+
+* ts_utils 1
+* ts_salobj 6.8
+* ts_idl 3.6
+* ts_tcpip 0.1
+* ts_xml 10.2
+* MTRotator IDL file, e.g. built using ``make_idl_file.py MTRotator`` (for `SimpleCsc` and unit tests)
+
 v0.28.0
 -------
 


### PR DESCRIPTION
This will prevent the CSC from assuming a particular state
for the low-level controller.
Eliminate wait_controller_state and wait_summary_state methods;
they are no longer needed.
Add some log messages to enable_controller.