### PR TITLE
Remove the deprecated state machine and copy the functions from ts_mt…

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,12 @@
 Version History
 ###############
 
+v1.3.0
+------
+
+* Remove the code related to the deprecated state machine in controller.
+* Migrate the functions from **ts_mtrotator**.
+
 v1.2.2
 ------
 

--- a/python/lsst/ts/hexrotcomm/base_csc_test_case.py
+++ b/python/lsst/ts/hexrotcomm/base_csc_test_case.py
@@ -95,15 +95,10 @@ class BaseCscTestCase(salobj.BaseCscTestCase):
                 # Wait for and check the intermediate controller state,
                 # so unit test code only needs to check the final state
                 # (don't swallow the final state, for backwards compatibility).
-                for controller_state in (
-                    ControllerState.OFFLINE,
-                    ControllerState.STANDBY,
-                    ControllerState.DISABLED,
-                ):
-                    await self.assert_next_sample(
-                        topic=self.remote.evt_controllerState,
-                        controllerState=controller_state,
-                    )
+                await self.assert_next_sample(
+                    topic=self.remote.evt_controllerState,
+                    controllerState=ControllerState.STANDBY,
+                )
             yield
 
     async def check_bin_script(

--- a/python/lsst/ts/hexrotcomm/enums.py
+++ b/python/lsst/ts/hexrotcomm/enums.py
@@ -49,14 +49,8 @@ class SetStateParam(enum.IntEnum):
     Called ``TriggerCmds`` in the Moog controller.
     """
 
-    # TODO DM-39787: delete START, DISABLE, EXIT, and ENTER_CONTROL
-    # once MTHexapod supports MTRotator's simplified states.
     INVALID = 0
-    START = 1
     ENABLE = 2
     STANDBY = 3
-    DISABLE = 4
-    EXIT = 5
     CLEAR_ERROR = 6
-    ENTER_CONTROL = 7
     FAULT = 8

--- a/python/lsst/ts/hexrotcomm/simple_csc.py
+++ b/python/lsst/ts/hexrotcomm/simple_csc.py
@@ -21,7 +21,6 @@
 
 __all__ = ["SimpleCsc"]
 
-from enum import IntEnum
 from pathlib import Path
 
 from lsst.ts import hexrotcomm, salobj, utils
@@ -162,6 +161,7 @@ class SimpleCsc(hexrotcomm.BaseCsc):
             followingErrorThreshold=0,
             trackingSuccessPositionThreshold=0,
             trackingLostTimeout=0,
+            drivesEnabled=client.config.drives_enabled,
         )
         await self.evt_commandableByDDS.set_write(state=True)
 
@@ -193,14 +193,8 @@ class SimpleCsc(hexrotcomm.BaseCsc):
             timestamp=utils.current_tai(),
         )
 
-    # TODO DM-39787: remove the initial_ctrl_state argument
-    # and always use STANDBY once MTHexapod supports
-    # MTRotator's simplified states.
-    def make_mock_controller(
-        self, initial_ctrl_state: IntEnum
-    ) -> simple_mock_controller.SimpleMockController:
+    def make_mock_controller(self) -> simple_mock_controller.SimpleMockController:
         return simple_mock_controller.SimpleMockController(
             log=self.log,
-            initial_state=initial_ctrl_state,
             port=0,
         )

--- a/python/lsst/ts/hexrotcomm/simple_mock_controller.py
+++ b/python/lsst/ts/hexrotcomm/simple_mock_controller.py
@@ -49,6 +49,7 @@ ENABLE_CONFIG = True
 
 class SimpleCommandCode(enum.IntEnum):
     SET_STATE = 1
+    ENABLE_DRIVES = 2
     SET_ENABLED_SUBSTATE = enum.auto()
     MOVE = enum.auto()
 
@@ -58,6 +59,7 @@ class SimpleConfig(ctypes.Structure):
 
     _pack_ = 1
     _fields_ = [
+        ("drives_enabled", ctypes.c_bool),
         ("min_position", ctypes.c_double),
         ("max_position", ctypes.c_double),
         ("max_velocity", ctypes.c_double),
@@ -113,9 +115,10 @@ class SimpleMockController(BaseMockController):
         log: logging.Logger,
         port: int = SIMPLE_TELEMETRY_PORT,
         host: str = tcpip.LOCAL_HOST,
-        initial_state: enum.IntEnum = ControllerState.OFFLINE,
+        initial_state: enum.IntEnum = ControllerState.STANDBY,
     ) -> None:
         config = SimpleConfig()
+        config.drives_enabled = False
         config.min_position = -25
         config.max_position = 25
         config.max_velocity = 47

--- a/tests/test_command_telemetry_client.py
+++ b/tests/test_command_telemetry_client.py
@@ -191,6 +191,7 @@ class CommandTelemetryClientTestCase(unittest.IsolatedAsyncioTestCase):
                 config = client.config
                 assert config.min_position == self.initial_min_position
                 assert config.max_position == self.initial_max_position
+                assert config.drives_enabled is False
                 telemetry = await asyncio.wait_for(
                     client.next_telemetry(), timeout=STD_TIMEOUT
                 )

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -230,10 +230,12 @@ class TestSimpleCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCase
             )
             await self.assert_next_summary_state(salobj.State.ENABLED)
 
-            self.csc.mock_ctrl.set_state(ControllerState.DISABLED)
+            assert self.csc.mock_ctrl.config.drives_enabled is True
+
+            self.csc.mock_ctrl.set_state(ControllerState.STANDBY)
             await self.assert_next_sample(
                 topic=self.remote.evt_controllerState,
-                controllerState=ControllerState.DISABLED,
+                controllerState=ControllerState.STANDBY,
             )
             await self.assert_next_summary_state(salobj.State.DISABLED)
 


### PR DESCRIPTION
* Remove the code related to the deprecated state machine in controller.
* Migrate the functions from **ts_mtrotator**.