### PR TITLE
Fix the race condition.

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -6,6 +6,13 @@
 Version History
 ###############
 
+v1.3.1
+------
+
+* Fix the race condition in ``BaseCsc.basic_telemetry_callback()`` with the ``BaseCsc.begin_disable()``.
+The reason we can do so is because the controller has a simplified state machine now.
+It only has the **Standby**, **Enabled**, and **Fault** states.
+
 v1.3.0
 ------
 

--- a/python/lsst/ts/hexrotcomm/base_csc.py
+++ b/python/lsst/ts/hexrotcomm/base_csc.py
@@ -709,10 +709,6 @@ class BaseCsc(salobj.ConfigurableCsc):
             return
 
         disable_conditions = []
-        if client.telemetry.state != ControllerState.ENABLED:
-            disable_conditions.append(
-                f"the low-level controller is in non-enabled state {client.telemetry.state!r}"
-            )
         if not self.evt_commandableByDDS.data.state:
             disable_conditions.append("the EUI has taken control")
         if disable_conditions:

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -216,29 +216,6 @@ class TestSimpleCsc(hexrotcomm.BaseCscTestCase, unittest.IsolatedAsyncioTestCase
             await self.remote.cmd_standby.start(timeout=STD_TIMEOUT)
             await self.assert_next_sample(topic=self.remote.evt_errorCode, errorCode=0)
 
-    async def test_controller_not_enabled(self) -> None:
-        """Controller going out of enabled state should disable the CSC"""
-        async with self.make_csc(
-            initial_state=salobj.State.ENABLED,
-            simulation_mode=1,
-            config_dir=TEST_CONFIG_DIR,
-        ):
-            await self.assert_next_sample(
-                topic=self.remote.evt_controllerState,
-                controllerState=ControllerState.ENABLED,
-                enabledSubstate=EnabledSubstate.STATIONARY,
-            )
-            await self.assert_next_summary_state(salobj.State.ENABLED)
-
-            assert self.csc.mock_ctrl.config.drives_enabled is True
-
-            self.csc.mock_ctrl.set_state(ControllerState.STANDBY)
-            await self.assert_next_sample(
-                topic=self.remote.evt_controllerState,
-                controllerState=ControllerState.STANDBY,
-            )
-            await self.assert_next_summary_state(salobj.State.DISABLED)
-
     async def test_eui_takes_control(self) -> None:
         """If the EUI takes control this should disable the CSC"""
         async with self.make_csc(


### PR DESCRIPTION
* Fix the race condition in ``BaseCsc.basic_telemetry_callback()`` with the ``BaseCsc.begin_disable()``.
The reason we can do so is because the controller has a simplified state machine now.
It only has the **Standby**, **Enabled**, and **Fault** states.
